### PR TITLE
Make maximum height configurable.

### DIFF
--- a/xnotify.1
+++ b/xnotify.1
@@ -76,6 +76,9 @@ Monitor numbers start from 0.
 Without this option,
 xnotify is displayed on the first monitor (that is, the monitor 0).
 .TP
+.BI "\-y " height
+Maximum height (in pixels) of a notification window.
+.TP
 .B \-o
 With this option,
 only one notification should exist at a time.
@@ -177,6 +180,9 @@ for more information.
 .TP
 .B xnotify.borderWidth
 The size in pixels of the border around a notification.
+.TP
+.B xnotify.maxHeight
+The maximum height of a notification window in pixels.
 .TP
 .B xnotify.gap
 The gap between notifications.

--- a/xnotify.1
+++ b/xnotify.1
@@ -10,6 +10,8 @@ xnotify \- popup a notification on the screen
 .IR button ]
 .RB [ \-g
 .IR geometry ]
+.RB [ \-h
+.IR height ]
 .RB [ \-m
 .IR monitor ]
 .RB [ \-s
@@ -70,14 +72,14 @@ and
 is the same as
 .BR "-g 0x0-10+10" .
 .TP
+.BI "\-h " height
+Maximum height (in pixels) of a notification window.
+.TP
 .BI "\-m " monitor
 Makes xnotify be displayed on the specified monitor.
 Monitor numbers start from 0.
 Without this option,
 xnotify is displayed on the first monitor (that is, the monitor 0).
-.TP
-.BI "\-y " height
-Maximum height (in pixels) of a notification window.
 .TP
 .B \-o
 With this option,

--- a/xnotify.c
+++ b/xnotify.c
@@ -44,7 +44,7 @@ volatile sig_atomic_t usrflag;  /* 1 if for SIGUSR1, 2 for SIGUSR2, 0 otherwise 
 void
 usage(void)
 {
-	(void)fprintf(stderr, "usage: xnotify [-o] [-G gravity] [-b button] [-g geometry] [-m monitor] [-s seconds] [-y height]\n");
+	(void)fprintf(stderr, "usage: xnotify [-o] [-G gravity] [-b button] [-g geometry] [-h height] [-m monitor] [-s seconds]\n");
 	exit(1);
 }
 
@@ -116,7 +116,7 @@ getoptions(int argc, char *argv[])
 	unsigned long n;
 	int ch;
 
-	while ((ch = getopt(argc, argv, "G:b:g:m:y:os:")) != -1) {
+	while ((ch = getopt(argc, argv, "G:b:g:h:m:os:")) != -1) {
 		switch (ch) {
 		case 'G':
 			config.gravityspec = optarg;
@@ -147,15 +147,15 @@ getoptions(int argc, char *argv[])
 		case 'g':
 			config.geometryspec = optarg;
 			break;
+		case 'h':
+			if ((n = strtoul(optarg, NULL, 10)) < INT_MAX)
+				config.max_height = n;
+			break;
 		case 'm':
 			mon.num = atoi(optarg);
 			break;
 		case 'o':
 			oflag = 1;
-			break;
-		case 'y':
-			if ((n = strtoul(optarg, NULL, 10)) < INT_MAX)
-				config.max_height = n;
 			break;
 		case 's':
 			if ((n = strtoul(optarg, NULL, 10)) < INT_MAX)

--- a/xnotify.c
+++ b/xnotify.c
@@ -44,7 +44,7 @@ volatile sig_atomic_t usrflag;  /* 1 if for SIGUSR1, 2 for SIGUSR2, 0 otherwise 
 void
 usage(void)
 {
-	(void)fprintf(stderr, "usage: xnotify [-o] [-G gravity] [-b button] [-g geometry] [-m monitor] [-s seconds]\n");
+	(void)fprintf(stderr, "usage: xnotify [-o] [-G gravity] [-b button] [-g geometry] [-m monitor] [-s seconds] [-y height]\n");
 	exit(1);
 }
 
@@ -88,6 +88,9 @@ getresources(void)
 	if (XrmGetResource(xdb, "xnotify.padding", "*", &type, &xval) == True)
 		if ((n = strtoul(xval.addr, NULL, 10)) < INT_MAX)
 			config.padding_pixels = n;
+	if (XrmGetResource(xdb, "xnotify.maxHeight", "*", &type, &xval) == True)
+		if ((n = strtoul(xval.addr, NULL, 10)) < INT_MAX)
+			config.max_height = n;
 	if (XrmGetResource(xdb, "xnotify.shrink", "*", &type, &xval) == True)
 		config.shrink = (strcasecmp(xval.addr, "true") == 0 ||
 		                strcasecmp(xval.addr, "on") == 0 ||
@@ -113,7 +116,7 @@ getoptions(int argc, char *argv[])
 	unsigned long n;
 	int ch;
 
-	while ((ch = getopt(argc, argv, "G:b:g:m:os:")) != -1) {
+	while ((ch = getopt(argc, argv, "G:b:g:m:y:os:")) != -1) {
 		switch (ch) {
 		case 'G':
 			config.gravityspec = optarg;
@@ -149,6 +152,10 @@ getoptions(int argc, char *argv[])
 			break;
 		case 'o':
 			oflag = 1;
+			break;
+		case 'y':
+			if ((n = strtoul(optarg, NULL, 10)) < INT_MAX)
+				config.max_height = n;
 			break;
 		case 's':
 			if ((n = strtoul(optarg, NULL, 10)) < INT_MAX)

--- a/xnotify.h
+++ b/xnotify.h
@@ -1,6 +1,6 @@
 /* macros */
 #define DEFWIDTH            350     /* default width of a notification */
-#define MAXLINES            10      /* maximum number of unwrapped lines */
+#define MAXLINES            128     /* maximum number of unwrapped lines */
 #define MIN(x,y)            ((x)<(y)?(x):(y))
 #define MAX(x,y)            ((x)>(y)?(x):(y))
 #define BETWEEN(x, a, b)    ((a) <= (x) && (x) <= (b))


### PR DESCRIPTION
I initially wanted to make the `MAXLINES` property configurable, but I think this makes more sense. The rationale given in #11 for `MAXLINES` is that it limits how large the notification can get, so that it doesn't span outside of the screen dimensions. But I don't think that it does, as it only measures the number of lines before wrapping? Thus, to control the window size, we need to control `max_height` instead.