### PR TITLE
Disable buffering on stdin

### DIFF
--- a/xnotify.c
+++ b/xnotify.c
@@ -1297,6 +1297,9 @@ main(int argc, char *argv[])
 	if (fcntl(STDIN_FILENO, F_SETFL, flags | O_NONBLOCK) == -1)
 		err(1, "could not set status flags for stdin");
 
+	/* disable buffering */
+	setbuf(stdin, NULL);
+
 	/* prepare the structure for poll(2) */
 	pfd[0].fd = STDIN_FILENO;
 	pfd[1].fd = xfd;


### PR DESCRIPTION
I've noticed that sometimes notifications don't show up when I am writing to the xnotify FIFO, but they do show up
together with newer notifications later.

I can reproduce the issue when I put many notifications in the FIFO at once (not all of the will show up), and then try to add some on top (now the old and the new notifications will appear together).

Debugging showed that the event loop becomes stuck in poll() before all sent notifications has been displayed.

Disabling buffering on stdin does fixes the problem for me. (I wonder why this buffering affects poll() in the first place, since poll() is supposed to operate on the file descriptor directly. Some glibc magic?).

My system is Linux with glibc, by the way.