### PR TITLE
fix \t and \n in the manpage

### DIFF
--- a/xnotify.1
+++ b/xnotify.1
@@ -340,7 +340,7 @@ after the line calling
 .BR xnotify .
 .IP
 .EX
-tiramisu -o "$(printf '#summary\t#body\n')" > $XNOTIFY_FIFO &
+tiramisu -o "$(printf '#summary\et#body\en')" > $XNOTIFY_FIFO &
 .EE
 .SH SEE ALSO
 .IR tiramisu (1),


### PR DESCRIPTION
As done in the other part of the manpage, to display a literal backslash `\e` must be used.