### PR TITLE
Pledge tightening

### DIFF
--- a/xnotify.c
+++ b/xnotify.c
@@ -1316,6 +1316,12 @@ main(int argc, char *argv[])
 	initstructurenotify();
 	initellipsis();
 
+#ifdef __OpenBSD__
+	/* drop "rpath unix" promises */
+	if (pledge("stdio", NULL) == -1)
+		err(1, "pledge");
+#endif
+
 	/* set up queue of notifications */
 	queue = setqueue();
 

--- a/xnotify.c
+++ b/xnotify.c
@@ -1278,14 +1278,15 @@ main(int argc, char *argv[])
 	int flags;              /* status flags for stdin */
 	int reading = 1;        /* set to 0 when stdin reaches EOF */
 
-#ifdef __OpenBSD__
-	if (pledge("stdio rpath unix", NULL) < 0)
-		err(1, "pledge");
-#endif
-
 	/* open connection to server and set X variables */
 	if ((dpy = XOpenDisplay(NULL)) == NULL)
 		errx(1, "could not open display");
+
+#ifdef __OpenBSD__
+	if (pledge("stdio rpath", NULL) == -1)
+		err(1, "pledge");
+#endif
+
 	screen = DefaultScreen(dpy);
 	root = RootWindow(dpy, screen);
 	visual = DefaultVisual(dpy, screen);


### PR DESCRIPTION
Hello,

This tightens pledge(2) usage on OpenBSD.  First, it drops the "unix" promise by calling pledge after XOpenDisplay and then, when the initalization is done, drops "rpath" too.  This greatly reduces the number of syscalls that remains available to the program during its main loop, without breaking it of course.  I'm testing it with tiramisu on OpenBSD and seems to work just fine.